### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/tuning.md
+++ b/doc/tuning.md
@@ -251,7 +251,7 @@ is described with examples at http://www.ericbrasseur.org/gamma.html
 
 By default QIS enables gamma correction so that resized images look correct,
 however the way this is currently implemented in QIS is very expensive in terms
-of performance. For a large speed-up at the expense of colour accurancy, you
+of performance. For a large speed-up at the expense of colour accuracy, you
 can disable gamma correction by adding this line to your QIS `local_settings.py`
 file:
 

--- a/src/imageserver/imaging_pillow.py
+++ b/src/imageserver/imaging_pillow.py
@@ -690,7 +690,7 @@ class PillowBackend(object):
     def _auto_crop_fit(self, image, top_px, left_px, bottom_px, right_px,
                        target_width, target_height):
         """
-        For the given image, cropped to the specified rectangle, and targetting
+        For the given image, cropped to the specified rectangle, and targeting
         an output size of target_width x target_height, widens the cropping rectangle
         either vertically or horizontally as far as possible, in order to reduce areas
         that would otherwise become background fill colour in the output image.

--- a/src/imageserver/static/js/canvas_view.js
+++ b/src/imageserver/static/js/canvas_view.js
@@ -2383,7 +2383,7 @@ ImgUtils.getImageSrc = function(el) {
 	return null;
 }
 
-/**** Private heleper functions ****/
+/**** Private helper functions ****/
 
 function _img_fs_zoom_click(imgEl, options, events) {
 	// Get image src or element background image

--- a/src/tests/junitxml/__init__.py
+++ b/src/tests/junitxml/__init__.py
@@ -87,7 +87,7 @@ class JUnitXmlResult(unittest.TestResult):
         """Create a JUnitXmlResult.
 
         :param stream: A stream to write results to. Note that due to the
-            nature of JUnit XML output, nnothing will be written to the stream
+            nature of JUnit XML output, nothing will be written to the stream
             until stopTestRun() is called.
         """
         self.__super = super(JUnitXmlResult, self)


### PR DESCRIPTION
There are small typos in:
- doc/tuning.md
- src/imageserver/imaging_pillow.py
- src/imageserver/static/js/canvas_view.js
- src/tests/junitxml/__init__.py

Fixes:
- Should read `targeting` rather than `targetting`.
- Should read `nothing` rather than `nnothing`.
- Should read `helper` rather than `heleper`.
- Should read `accuracy` rather than `accurancy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md